### PR TITLE
fix: successorPath, successorPrefix had wrong behaviour

### DIFF
--- a/src/areas/areas.ts
+++ b/src/areas/areas.ts
@@ -194,6 +194,11 @@ export function areaTo3dRange<SubspaceType>(
       start: area.pathPrefix,
       end: successorPrefix(
         area.pathPrefix,
+        {
+          maxComponentCount: opts.maxComponentCount,
+          maxComponentLength: opts.maxPathComponentLength,
+          maxPathLength: opts.maxPathLength,
+        },
       ) || OPEN_END,
     },
   };

--- a/src/order/successor.test.ts
+++ b/src/order/successor.test.ts
@@ -11,34 +11,44 @@ const maxComponentLength = 2;
 const testVectorsSuccessorPath: VectorSuccessorPath[] = [
   [
     [],
-    [new Uint8Array(1)],
+    [new Uint8Array([])],
   ],
   [
     [new Uint8Array([0])],
-    [new Uint8Array([0, 0])],
+    [new Uint8Array([0]), new Uint8Array([])],
   ],
+
   [
     [new Uint8Array([0, 0])],
-    [new Uint8Array([0, 1])],
+    [new Uint8Array([0, 0]), new Uint8Array([])],
   ],
+
   [
     [new Uint8Array([0, 0]), new Uint8Array([0])],
+    [new Uint8Array([0, 0]), new Uint8Array([0]), new Uint8Array()],
+  ],
+
+  [
+    [new Uint8Array([0, 0]), new Uint8Array([0]), new Uint8Array()],
     [new Uint8Array([0, 0]), new Uint8Array([1])],
   ],
+
   [
-    [new Uint8Array([0, 0]), new Uint8Array([255])],
+    [new Uint8Array([0, 0]), new Uint8Array([255]), new Uint8Array([])],
     [new Uint8Array([0, 1])],
   ],
+
   [
-    [new Uint8Array([0, 255]), new Uint8Array([0])],
+    [new Uint8Array([0, 255]), new Uint8Array([0]), new Uint8Array()],
     [new Uint8Array([0, 255]), new Uint8Array([1])],
   ],
   [
     [new Uint8Array([0]), new Uint8Array([0]), new Uint8Array([0])],
     [new Uint8Array([0]), new Uint8Array([0]), new Uint8Array([1])],
   ],
+
   [
-    [new Uint8Array([255]), new Uint8Array([255]), new Uint8Array([255])],
+    [new Uint8Array([255, 255]), new Uint8Array([255]), new Uint8Array([])],
     null,
   ],
 ];
@@ -68,45 +78,54 @@ const testVectorsSuccessorPrefix: VectorSuccessorPrefix[] = [
     [],
     null,
   ],
+
   [
     [new Uint8Array()],
     [new Uint8Array([0])],
   ],
+
   [
     [new Uint8Array([1]), new Uint8Array([])],
     [new Uint8Array([1]), new Uint8Array([0])],
   ],
+
   [
     [new Uint8Array([0])],
-    [new Uint8Array([1])],
+    [new Uint8Array([0, 0])],
   ],
+
   [
     [new Uint8Array([0, 0])],
     [new Uint8Array([0, 1])],
   ],
+
   [
     [new Uint8Array([0, 0]), new Uint8Array([0])],
     [new Uint8Array([0, 0]), new Uint8Array([1])],
   ],
+
   [
     [new Uint8Array([0, 0]), new Uint8Array([255])],
     [new Uint8Array([0, 1])],
   ],
+
   [
     [new Uint8Array([0, 255]), new Uint8Array([0])],
     [new Uint8Array([0, 255]), new Uint8Array([1])],
   ],
+
   [
     [new Uint8Array([0]), new Uint8Array([0]), new Uint8Array([0])],
     [new Uint8Array([0]), new Uint8Array([0]), new Uint8Array([1])],
   ],
+
   [
-    [new Uint8Array([255]), new Uint8Array([255]), new Uint8Array([255])],
+    [new Uint8Array([255, 255]), new Uint8Array([255])],
     null,
   ],
 ];
 
-Deno.test("successorPrefix", () => {
+Deno.test.only("successorPrefix", () => {
   for (const [original, successor] of testVectorsSuccessorPrefix) {
     if (successor) {
       assert(
@@ -117,6 +136,7 @@ Deno.test("successorPrefix", () => {
     assertEquals(
       successorPrefix(
         original,
+        { maxComponentCount, maxComponentLength, maxPathLength },
       ),
       successor,
     );

--- a/src/parameters/types.ts
+++ b/src/parameters/types.ts
@@ -10,7 +10,11 @@ export type KeypairEncodingScheme<PublicKey, Signature> = {
 
 /** A scheme for signing and verifying data using key pairs. */
 export type SignatureScheme<PublicKey, SecretKey, Signature> = {
-  sign: (publicKey: PublicKey, secretKey: SecretKey, bytestring: Uint8Array) => Promise<Signature>;
+  sign: (
+    publicKey: PublicKey,
+    secretKey: SecretKey,
+    bytestring: Uint8Array,
+  ) => Promise<Signature>;
   verify: (
     publicKey: PublicKey,
     signature: Signature,


### PR DESCRIPTION
This is the first of many PRs with improvements yielded from our work on https://github.com/earthstar-project/willow-rs! (https://github.com/earthstar-project/willow-rs/pull/22)

Path successors. Thought we had them licked, we were wrong. My previous implementation ignored the existence of empty components, and many edge-cases resulting from different combinations of path parameters.

The updated implementation here is ported from willow-rs, with some updated test vectors. These vectors will at some point be replaced by vectors generated by willow-rs.

As this change adds required parameters to a function, it is a breaking change.